### PR TITLE
styled category page from real example

### DIFF
--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -17,7 +17,9 @@
     {#if data.posts}
     {#each data.posts as post}
     <!-- @html means: there is html in this string, render it -->
-        <a href="/{post.slug}">
+        <div class="posts-grid">
+            <div class="post-container">
+            <a href="/{post.slug}">
             <h3>{@html post.title.rendered}</h3>
         </a>
         <p>{@html post.excerpt.rendered}</p>
@@ -25,6 +27,8 @@
         <p>{(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}</p>
         <p>{post.yoast_head_json.twitter_misc["Geschatte leestijd"]}</p>
         <p>{post.yoast_head_json.author}</p>
+        </div>
+    </div>
     {/each}
 {:else}
     <!-- This will show if no posts are available -->
@@ -33,3 +37,31 @@
 </main>
 
 <Footer />
+
+<style>
+  main {
+    border: 1px solid black;
+    padding: 1.5em;
+  }
+
+  .posts-grid {
+    display: flex;
+    flex-wrap: wrap;
+    border-bottom: 1px solid #787878; 
+
+  }
+  
+.post-container {
+    padding-bottom: 1em; 
+    margin-bottom: 1em; 
+    
+}
+  
+  .post-container:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+
+</style>


### PR DESCRIPTION
## Beschrijving

In deze pull request zijn de categoriepagina's aangepast naar het voorbeeld op de echte Red Pers website. De artikelen per categorie worden nu in een soort "box" getoond met een border onderop om de artikelen te scheiden.

## Voorbeeld

De categoriepagina ziet er nu als volgt uit:
![Schermafbeelding 2025-01-09 211329](https://github.com/user-attachments/assets/12dac48b-9355-44c3-86f3-f61178a056cb)


### How has this been tested?

- [x] Accessibility test
- [x] Performance test
- [x] Responsive test
- [x] Browser test

**1. Accessibility test**
Met behulp van Lighthouse heb ik een accessibility test gedaan op zowel desktop als mobiel formaat:

Desktop:
![Schermafbeelding 2025-01-09 213110](https://github.com/user-attachments/assets/795c7251-bffc-474d-bbe7-19fe83e4d8ec)


Mobiel:
![Schermafbeelding 2025-01-09 213206](https://github.com/user-attachments/assets/36b5fe0e-5cf2-430f-a5e5-1f91da007819)



**2. Performance test**

Desktop:
![Schermafbeelding 2025-01-09 205423](https://github.com/user-attachments/assets/779ee848-db8a-4934-b8ba-82a3d7e54782)


Mobiel:
![Schermafbeelding 2025-01-09 205345](https://github.com/user-attachments/assets/a55d09ea-3bd6-4cb2-9525-4f574c2d89db)


3. Responsive test

![Schermafbeelding 2025-01-09 214743](https://github.com/user-attachments/assets/eb394115-f5e3-47ec-b323-603cc76bf549)

![Schermafbeelding 2025-01-09 214816](https://github.com/user-attachments/assets/7397195a-5efa-458f-a7fb-9a7e4af9ed01)

De website is goed responsive op meerdere browsers.

**4. Browser test**

De pagina is getest in browsers als Arc, Opera GX, Mozilla Firefox en Google Chrome. In bijna alle browsers werkt de pagina naar behoren. Enkel in Opera GX staat de geforceerde dark mode aan.

![Schermafbeelding 2025-01-09 215053](https://github.com/user-attachments/assets/bd68ca2d-b1b5-4c63-a6dd-bd4ec4194e55)

Chrome:
![Schermafbeelding 2025-01-09 215120](https://github.com/user-attachments/assets/bb8e172d-5fae-47ad-bca3-485d08f0d5a6)

Mozilla
![Schermafbeelding 2025-01-09 215137](https://github.com/user-attachments/assets/452189d8-d3b8-4a09-87c7-5355f2ba83da)



###How to review
- Ga naar de branch waarin deze aanpassingen zijn doorgevoerd (```styling-overige-paginas```).
- Controleer de visuele weergave van de categorieen en beoordeel of de artikelen netjes onder elkaar staan.
- Controleer of de responsive weergave goed functioneert.
- Controleer of de overige artikelen er nog steeds goed uitzien.


###Resultaten van de testen

**Accessibility test**

- Qua toegankelijkheid zijn er geen grote problemen gevonden

**Responsive test**

- De pagina schaalt op verschillende groottes mee en breekt niet

**Browser test**

De functionaliteit van de pagina werkt bijna overal hetzelfde. Enkel op Opera GX werd de pagina geforceerd donker gemaakt.



